### PR TITLE
Allow external_id to be the sole customer identifier for events

### DIFF
--- a/template.js
+++ b/template.js
@@ -440,6 +440,7 @@ function hasUserIdentificationData(klaviyoEventData) {
   return (
     !!profileData.id ||
     !!profileData.attributes.email ||
-    !!profileData.attributes._kx
+    !!profileData.attributes._kx ||
+    !!profileData.attributes.external_id
   );
 }


### PR DESCRIPTION
We use external_id as the only identifier we share to GA when the event isn't related specifically to an email subscription.