### PR TITLE
Don't retrieve and use email from cookie if storing not enabled

### DIFF
--- a/template.js
+++ b/template.js
@@ -208,7 +208,7 @@ function getCustomerProperties() {
 
   if (data.email) customerProperties.email = data.email;
   else if (eventData.email) customerProperties.email = eventData.email;
-  else {
+  else if (data.storeEmail) {
     let emailCookie = getCookieValues('stape_klaviyo_email');
     if (emailCookie.length) customerProperties.email = emailCookie[0];
   }

--- a/template.tpl
+++ b/template.tpl
@@ -709,7 +709,7 @@ function getCustomerProperties() {
 
   if (data.email) customerProperties.email = data.email;
   else if (eventData.email) customerProperties.email = eventData.email;
-  else {
+  else if (data.storeEmail) {
     let emailCookie = getCookieValues('stape_klaviyo_email');
     if (emailCookie.length) customerProperties.email = emailCookie[0];
   }


### PR DESCRIPTION
Because of the issue fixed in 7140d1a3f2e8d724f2efb732b01fd38dd479557d, many people will have cookies with this email set. If they then update to a fixed version and leave this field disabled they may believe email is *not* being sent to Klaviyo when it may indeed be, even if not included in event properties.

By only retriving the email from cookie when storing the cookie is enabled, we sidestep this issue.