### PR TITLE
Bump API version to 2025-01-15

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "printWidth": 100
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: "https://stape.io/"
 versions:
   - sha: f72e6991c9dc7461c56101c48266c4fcea2c6285
-    changeNotes: Update API to 2025-01-15.
+    changeNotes: Updated API to 2025-01-15. Added consent checking. 
   - sha: 0beb2843e3eabfe8493b570e3f976fb9dce40664
     changeNotes: Added Create or Update Profile option. Added some tests.
   - sha: c23350035e89fd29a734c3246c4cfd12f3739eab

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 homepage: "https://stape.io/"
 versions:
-  - sha: 891c878f77abc134bfec9f6ddf425f6655616a39
+  - sha: f72e6991c9dc7461c56101c48266c4fcea2c6285
     changeNotes: Update API to 2025-01-15.
   - sha: 0beb2843e3eabfe8493b570e3f976fb9dce40664
     changeNotes: Added Create or Update Profile option. Added some tests.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: "https://stape.io/"
 versions:
+  - sha: 891c878f77abc134bfec9f6ddf425f6655616a39
+    changeNotes: Update API to 2025-01-15.
   - sha: 0beb2843e3eabfe8493b570e3f976fb9dce40664
     changeNotes: Added Create or Update Profile option. Added some tests.
   - sha: c23350035e89fd29a734c3246c4cfd12f3739eab

--- a/template.js
+++ b/template.js
@@ -11,7 +11,6 @@ const decodeUriComponent = require('decodeUriComponent');
 const getContainerVersion = require('getContainerVersion');
 const logToConsole = require('logToConsole');
 const getRequestHeader = require('getRequestHeader');
-const getType = require('getType');
 
 const eventPropertiesToIgnore = [
   'x-ga-protocol_version',
@@ -41,7 +40,7 @@ const actionTypes = {
   ACTIVE_ON_SITE: 'active_on_site',
   CREATE_OR_UPDATE_PROFILE: 'createOrUpdateProfile'
 };
-const klaviyoApiRevision = '2024-06-15';
+const klaviyoApiRevision = '2025-01-15';
 
 const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
@@ -74,37 +73,31 @@ function sendEvent() {
   if (!hasUserIdentificationData(klaviyoEventData)) {
     return data.gtmOnSuccess();
   }
-  
+
   const url = 'https://a.klaviyo.com/api/events/';
 
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Klaviyo',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: eventNameLogs,
-        RequestMethod: 'POST',
-        RequestUrl: url,
-        RequestBody: klaviyoEventData
-      })
-    );
-  }
+  log({
+    Name: 'Klaviyo',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: eventNameLogs,
+    RequestMethod: 'POST',
+    RequestUrl: url,
+    RequestBody: klaviyoEventData
+  });
 
   sendHttpRequest(
     url,
     (statusCode, headers, body) => {
-      logToConsole(
-        JSON.stringify({
-          Name: 'Klaviyo',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: eventNameLogs,
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body
-        })
-      );
+      log({
+        Name: 'Klaviyo',
+        Type: 'Response',
+        TraceId: traceId,
+        EventName: eventNameLogs,
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
 
       if (!data.useOptimisticScenario) {
         if (statusCode >= 200 && statusCode < 300) {
@@ -150,7 +143,7 @@ function addToList() {
       }
     }
   };
-  
+
   const subscriptions = {};
   if (data.subscribeToMarketingEmails) {
     subscriptions.email = {
@@ -165,42 +158,32 @@ function addToList() {
         consent: 'SUBSCRIBED'
       }
     };
-    let phone = '';
-    if (data.phone) {
-      phone = data.phone;
-    }
-    addToListData.data.attributes.profiles.data[0].attributes.phone_number = phone;
+    addToListData.data.attributes.profiles.data[0].attributes.phone_number = data.phone || '';
   }
   addToListData.data.attributes.profiles.data[0].attributes.subscriptions = subscriptions;
 
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Klaviyo',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: 'add_to_list',
-        RequestMethod: 'POST',
-        RequestUrl: url,
-        RequestBody: addToListData
-      })
-    );
-  }
+  log({
+    Name: 'Klaviyo',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: 'add_to_list',
+    RequestMethod: 'POST',
+    RequestUrl: url,
+    RequestBody: addToListData
+  });
 
   sendHttpRequest(
     url,
     (statusCode, headers, body) => {
-      logToConsole(
-        JSON.stringify({
-          Name: 'Klaviyo',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: 'add_to_list',
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body
-        })
-      );
+      log({
+        Name: 'Klaviyo',
+        Type: 'Response',
+        TraceId: traceId,
+        EventName: 'add_to_list',
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
 
       if (!data.useOptimisticScenario) {
         if (statusCode >= 200 && statusCode < 300) {
@@ -220,39 +203,33 @@ function addToList() {
 
 function createOrUpdateProfile() {
   const url = 'https://a.klaviyo.com/api/profile-import/';
-  
+
   const updateProfileData = {
     data: getProfileData()
   };
-  
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Klaviyo',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: 'createOrUpdateProfile',
-        RequestMethod: 'POST',
-        RequestUrl: url,
-        RequestBody: updateProfileData
-      })
-    );
-  }
-  
+
+  log({
+    Name: 'Klaviyo',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: 'createOrUpdateProfile',
+    RequestMethod: 'POST',
+    RequestUrl: url,
+    RequestBody: updateProfileData
+  });
+
   sendHttpRequest(
     url,
     (statusCode, headers, body) => {
-      logToConsole(
-        JSON.stringify({
-          Name: 'Klaviyo',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: 'createOrUpdateProfile',
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body
-        })
-      );
+      log({
+        Name: 'Klaviyo',
+        Type: 'Response',
+        TraceId: traceId,
+        EventName: 'createOrUpdateProfile',
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
 
       if (!data.useOptimisticScenario) {
         if (statusCode >= 200 && statusCode < 300) {
@@ -450,10 +427,7 @@ function getViewedItems() {
 
 function updateViewedItems(viewedItems) {
   for (let key in viewedItems) {
-    if (
-      viewedItems[key].ItemId &&
-      makeString(viewedItems[key].ItemId) === eventData.ItemId
-    ) {
+    if (viewedItems[key].ItemId && makeString(viewedItems[key].ItemId) === eventData.ItemId) {
       viewedItems[key].Views = makeInteger(viewedItems[key].Views) + 1;
 
       return viewedItems;
@@ -492,20 +466,25 @@ function hasItem(arr, item) {
   for (let k in arr) {
     if (arr[k] === item) return true;
   }
-
   return false;
 }
 
 function buildRequestHeaders() {
   return {
-    'X-Forwarded-For': eventData.ip_override 
+    'X-Forwarded-For': eventData.ip_override
       ? eventData.ip_override.split(' ').join('').split(',')[0]
       : getRemoteAddress(),
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
+    'Content-Type': 'application/vnd.api+json',
+    Accept: 'application/vnd.api+json',
     Revision: klaviyoApiRevision,
     Authorization: 'Klaviyo-API-Key ' + data.apiKey
   };
+}
+
+function log(logObject) {
+  if (isLoggingEnabled) {
+    logToConsole(JSON.stringify(logObject));
+  }
 }
 
 function determinateIsLoggingEnabled() {

--- a/template.js
+++ b/template.js
@@ -47,6 +47,10 @@ const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
 
 const eventData = getAllEventData();
 
+if (!isConsentGivenOrNotRequired()) {
+  return data.gtmOnSuccess();
+}
+
 switch (data.type) {
   case actionTypes.ADD_TO_LIST:
     addToList();
@@ -485,6 +489,13 @@ function log(logObject) {
   if (isLoggingEnabled) {
     logToConsole(JSON.stringify(logObject));
   }
+}
+
+function isConsentGivenOrNotRequired() {
+  if (data.adStorageConsent !== 'required') return true;
+  if (eventData.consent_state) return !!eventData.consent_state.ad_storage;
+  const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
+  return xGaGcs[2] === '1';
 }
 
 function determinateIsLoggingEnabled() {

--- a/template.tpl
+++ b/template.tpl
@@ -540,6 +540,31 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
+    "type": "GROUP",
+    "name": "consentSettingsGroup",
+    "displayName": "Consent Settings",
+    "groupStyle": "ZIPPY_CLOSED",
+    "subParams": [
+      {
+        "type": "RADIO",
+        "name": "adStorageConsent",
+        "displayName": "",
+        "radioItems": [
+          {
+            "value": "optional",
+            "displayValue": "Send data always"
+          },
+          {
+            "value": "required",
+            "displayValue": "Send data in case marketing consent given"
+          }
+        ],
+        "simpleValueType": true,
+        "defaultValue": "optional"
+      }
+    ]
+  },
+  {
     "displayName": "Logs Settings",
     "name": "logsGroup",
     "groupStyle": "ZIPPY_CLOSED",
@@ -620,6 +645,10 @@ const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
 
 const eventData = getAllEventData();
+
+if (!isConsentGivenOrNotRequired()) {
+  return data.gtmOnSuccess();
+}
 
 switch (data.type) {
   case actionTypes.ADD_TO_LIST:
@@ -1059,6 +1088,13 @@ function log(logObject) {
   if (isLoggingEnabled) {
     logToConsole(JSON.stringify(logObject));
   }
+}
+
+function isConsentGivenOrNotRequired() {
+  if (data.adStorageConsent !== 'required') return true;
+  if (eventData.consent_state) return !!eventData.consent_state.ad_storage;
+  const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
+  return xGaGcs[2] === '1';
 }
 
 function determinateIsLoggingEnabled() {

--- a/template.tpl
+++ b/template.tpl
@@ -24,7 +24,7 @@ ___INFO___
     "displayName": "stape-io",
     "thumbnail": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPAAAADwCAMAAAAJixmgAAAAAXNSR0IArs4c6QAAAvFQTFRFR3BMJa9rJa9rJa9rJa9rQL+AAP8ABKpVJa9rAICAJLZtM5lmJa9rJa9qAP+AK6qAJa5rJa5rAP//AAAAIJ9gJa9sJa9rJa9rK6pVM8xmJbBrJK9rJbBrJa5rHKxxJa9rJa5qI7BqLbNxIL9gJa9rJq9sJa9rI69qJa9rJa9rJa9rJK9rIq9pJrFmJa9rJK9rJK9qJa9rJa9rQIBAJK9rJa9rJK9rI69rJa9rJa9rJa9rJLBrJq5rJa9rJq9rJa9rJa9sJa5rJa9rJK9rJa9qJa9rJa5rJa9rJbBrJK1qJ7FsIqpmH69kJrBsJa9rJJJtJa9rKK9oJa9rJK1tJa9rJK9rJa9rJa9rJLBrJLBrJa9rJrBsJK9rJbBrIq5uJa9rJq9sJK9rJK9rJa9rJbBqJa5qJbBrJq9qJa9qJa5rJa9rJa9rJrBrQICAJK5qJ7BsJK9rJa9rJbBrIL+AI69qJa9rJa9rJLBrJa9rJa9qJa5rJK9rJq1pJq5oJq9rJ7FtJq5qJbBrJq9tJa9qJa5qJK9rJK9rJrBrI65oJK9rJa9rJa9sJLBrJK1tJq9sJa5rJLBqJa5rJbBrJrBrJK9rJK9qJa9rJa9rJq9qJbBrJa9rJa9qJbBrJa9sJa9rJbBrJa9qJa9rJbBrJa9sJq5rJa9rKK5rJa5rJq9qJK9qJq9rJq9sJa9sJbFrJa9rJa5qJbBrJa9rJa5qJa9rJK9sJLBrJa5rJrBsJbBsJa9rJK9rJbBrJa5rJ69pJbBrJa5rJbBrJK5qJq5qJbBrJLBrJK9sJa9rJrFrJa9rJK5tJbBsJ61sJa9rJK9qJbBrJq5qJq9rJLBrJrNzJbBrJbBrJK9sJK1qJrBsJK5qJLBsJa5qJa9rKLxzJbBrJ7pyJ7lxJ7hxJrJtJbBsJ7dwJrRuJrVvJrZvJ7tyJbFsJ7hwJrNuKL10JrNtKLtyKL50KLtzKL1zJ7ZvJ7ZwJrVuJ7pxJrFsKL91JrFtJa5rJbFtKcR4iThWOgAAAPt0Uk5TAP74/fwEAQP7AgcF+v4CBv36AQEI+fb5BgX3/P73CfL3HQsI4jXwJO2zHk4WFIcqtqmQBD/lIznp7t9pX3Je5235dHDP6sGZURgaDwot3QfrIJYO72G1sEdazT29NxD1zCXSdsIp+2yJmNtLSQRjIcymqggz9Nx/yjBBMSIbJw1lbi9ni8PZmyzgu1VdHETXTdHRt4T8oMVzgpx9v62RntO52NS+1RPzUH95ZsBFb8fIo66Nk3fkjvSy9XpFLkK3rqFXV4xjpWW8Fc472kaXPOA4FKT4tlSVmpq0///////////////////////////////////////////j/VQOAAAXEUlEQVR42u1dd3wTV55/UySNykgj25JsyR3c6MUGApgWYzqB0EILhIROaMlSEkoKKaT3BFI2JAQ2vfeym2xJ2b57t3t3U6VRl2UbCMne/XVvZJxAsEYjWyOXne8HDHyQRvq+8uvv9wDQoEGDBg0aNGjQoEGDBg0aNGjQoEGDBg0aNGjQoEGDBg0aNGjQoKED5OhMEDrjvwfbXFueoe1vhjxTbt/nayuQfswsK5tpg38pMPVxutY8AMoWHW28fe7c5xp/vnUAAHnWPj29ejBgRH8vxwkRQeA473sj5oPcy/osXT1cv+vHCKe9GGGBIKjvTwlTJwFg0vdNvjo9GDUsGEAIHKETQHACCQR/OQrodX1ROENS4yoFGifp80DitFA5Dg5GnxPXUOcOGCY0XUi3jXKTMGxb4gV9ydKAdG46yVEY3QEwjF/1GnxNTt+hCzXP/JpQE0EnAeFtuesA1Fl9hLIBCuFxJQxB0UmBEXEnFNd6Q1/YvGYAhj7MRFFaFpO9zMNDATD3+q1stgLrpBLGQbDyhFnCwZRMsibGpzfvXmhqfLo45HcidEogTn9o8S3QDOnFk1xgBtZLFzIWF0srAOsimIVXXwZ0Bb2V73UA7B0mBJyYIr6QMeY8w61YCUBx77QkTUD3cTWDoXQamIy3lDxpAKZeaGtCP3BloxBEcTYdwiyFBoTGlYm39y5lBL/w7g842kGnDTvNfbC7t/nJ+QBUPC4ECJzuBHAiIDxeAZ3nXuX37kZ5mqA7CYLm3Ud0IL+XmJpQ4Nz4Bh/FMbrTwKgo983oxKN6vq1hAIbdFp6k6C4BIyOFj1iBoadPsmT+Vyxjwngh3UUgeDi+rKLN9ejBjhFchS/SEQtJZwCkJUK/qEs8tKfqIml69zBQsWQIdprZI01yD9VQ0M/JexLjUYrNFGFohvDYkfLEo3scrPBLjX485nPTGQXqa15WC92QHjfJ0EpY8CLRghJsZgmzniKOHrKgp5khkiV533amyUmrgNKzsdX3we3Sg/xkmw7MOkQxdjurBmHW4mKwQ7OArqfkZHKh+3pFAxMtImmVgBRFmYYroJ/cI8yQAhs4+D4ewu20irDjoXXPnADm/O7n2w+APz7IRV0YrSowV5S7f2Di47rXtDKD8hGYgBG06iCwCD1tATB3q+FVAMDm2yNeAqOzAIzw8n/YnPjQ7lJGVlC+8WyQxOksgcKCZzeWA2s3KSi4tq7YxfkohM4aEMrH7YLi2pD97GouHOXyf/qDeBbptnmNQf8/oeFlzDJlI+T76iaGxumsA6eZ/g+0fYPsufnQS73ymYBoL6S7AYWOYGTa4EQJRbY270gABu6KIRa6m2DBm8dCnTwySxoKWjszNgaForR0EbSyC0nqUcLuQl0uRxtcLhR1WQgcS1sOkKVicOMMaMRnYScbIN/pm5qVZ1BYyJRwuFGHBae/9wciPM9x336b+P0tz4uBpjAiDQNql+SfYu8DxZo3TYc6WfW4pglO77Qm3qk0g4JZ3G4HHg5y8RaGOeVznJw3ceyDD655aM1DD6158Pn3xlSvwr1CKxOP837oFRWhBKmMNIs7+aZp+xNfSM3phX7v3be3sqWKZpZyOVEqyjFM3Fd5+PWn/7l7/dIto4duu3fw4L8NHiz9GDRg1N7agYvqhzw2rGHiKn8rwwhhwu20Y4pIl7LMrnugn6ziTjblgplHwzxK+FLrS4sTJU8zMWHVrmPvXDq94t6Dsq5d/pVVtUuffOz192gm1uL3uEuJwpScWQLlm/4+AOSqNcn66wAYP5fzpt695ORSwt8aC0x8ZcSi0ft/sH0NOnO+yZRnsv2APPiPfPOPhdOzq169+bHVJXxzS9jhtKeWZe5w6PB4AK5TRUFBN6VseJPgSeUYkQ43Fonx1Xcd2Vx1buytugJbgc6qz01mtRl0Npu5Xa8uuOWLd7a7mFiAKLKknGQi0jS8DBhUcCjg7h1fx3lTxdgJlIw0R++fdndVW5zRqDNDpkqzNGbzyLbXlu+9aWedGAsSKJ5q63i5uvGZzycbdGDm8DOnMfmPJ+2eYMzbMOSGWecC84q5np+s0Z1LKM34xbS5IhMlCPmljWOnz+zcDwzXZtjvvWcMF5b3FKh13ri46f3fJ5ZXrtXQeWMXrvG2N8/a8thUnvfJ+9sIHuarb8qkn2zNBTOGnw5QMh+LIBgdDJ3csXl2YpaMXXdm4DMSq2PQ+F+ua/EjGFIol131Cx+WgdzMKCjo5oMJYzhEJv9JYkiYDzx7dZm0EXP0GZOZen1i4NYOOSyKYRIj5UID3MJFIBOhASn/WfY057ckH2ASp/08UfMA3HnWzHvmemlHF4+/zSc00bgMZUvTt2/BAe9qQll6/4RqxuKRiTTRAfGSo9dLO10lFzWhdD7b6Y74EYJMbmtamOoJXSxQ1ZsBmD+ci7pltAISjMx7fxQA19pUdE+NJjjw199RIgQwmaXmjnLD50ODodOTrIODNX5MzG5JaknaPaf4MSMgXZvauS69VKt2yx0Lvw0QSa0Rn8Uem3qrpPs7+REAVA3ng8kLQz3omXj1iKugjZ2N1F6uCTqmN/7XSaYpuTGCOAPckqGdOydjLgDGW+ua8f9IZsQjbjaG3nELnN2snS7Lg1M3ejjNIKhMgWpz9fpEWWuaKAZgTo0gliZL57MWBxesqYXrPptFgnrJF9z8SoRPmodmsVJRqJmTboHqtZDFpfNa6aQjWej0tj6/VBr0LBfZSJnoy24d2+xL7pKjSOu8SwHol8ZOhg+dM+y06MKTSgcXY39kMNwr3ZDoGQl3UNkzLJfcK8dd4ulhc5Qn3qzQ762v5tjkhaGl3pavVsLV3E2FclI+7bM3GJ87aYzAxXLVVystUIWycO2xYPLCUBZHQydvhp9p7rbTZJJ9UPwiybsxmQJVsXFvgkyqZ0GrZspCnk7uk9l9zIq10Pzp1pILKxzwlduZ5PWrCEELH70EGetTJsjuvE2IJneMEEvE91KiorK7M9N6kH8oGkgeE8Hwpshtd8oX8unhmr8aFUgsqflG/St++++7JXvXoVtzRV0cSzo3hRgpoHAnJw1C6OEiXXtNyJs8qlEIB+13B7OY1EmhogxgxmLurEwUBveGroGGl1GfxM0H9XbuUVLGDxTxST2qDhAKnCPeoIzXSD7KOaYYQK61o9ECQ48zXplaHBzh+i8Hhh5V3AoX28CpPCYTnLB/H3v8+otlLNSoBfVFLXaZ5UH4uOMzMpHZyNXrjQno9V0XBTk2UNXA0TIVj7grhL9kShzY/nE1S4cyGmPeIplQmcsr/nfXoqE5BrPNVmDWGdoXidVg0OkKbDZzl8IUeaB4OO+TKwJ0n41dUwE11A/rOt8I+n2MMqhF5k2oP/xu5zNXRrPJZrbK/b/N1OmDpfBLHQrI5UNYApL7+DqgP+fFwj9GvxJvkj0Q6RTdSzsproymvPbjKf0GV63ccvfWm+sf2TBkyIYhT9z85RebR1/1dXG7zZNn6lSVMCQwiT5TJDNdhc6meOPoc4aXDswaUsLYHXLJK+e31fdJwfj0hUq/tu4zswfU/vbI51+9UFdJnBWZdrQKXqxk4nNPvTnkpvtGzW6brn6d+BQ4EXe7RblSXtZhYU7+5gRInCi4s6ElWoTJjg8/tiIR8EmTbXFiDQ1aPmljY3+nn2HiIV7Kf69LtPGwWAiC9HkDQijOtPrRusY76msHJSasOG3OOiv4ZJ4gyxhzR5kXPpXsrgH9Yw67fC1ry9wDwJbmFrPmSdW+tr++tuM555kWyNSH211u1EHgFEkihQj8RZIYTthR92Q74fMLHBN037+zfqU0SJelexAPrr7R8/gi+QJVV2vdAPjaxd+tkk2QIQ7um32SYEtrkUniPO/Vt7eXnOEgV499sl0uT4Pglsn2db4AzwVKtr/9auLN6QkMqxl8OpaXz+SSq5qPAfAAL5+sQiyh1YNAejHYAimQfMOIZ3GBD4Rxi0VZ9RpCwVdC0gL+7IgbQLpxKWM+uGosb0+RauQfADtCLtnXEPw3X4N0atFzpbjw/HcbMEGMQr80vcpEhIJ+eFQUsO3vzk8z3gqVzoG/ROSz13ZuJ6gOyy5ogj9clo76TRg0tTsqI6KXpvBO1ciTOEV7xUjlm38G6fllJnBjpSjLGAlfAsKyM4BH+lelwVdyuAy/ftzLN9EY1oUTASR0+pp43/FfABnvriOF/NeSoGwKG/EB+WRzsHKOcr5GuJave3mNGKExsss1pwhJsZFgw1Jj23OVzvFnmF+OcaEPONl/Jf1vj5/4s2K+UlrVMP4PoSCesYpTnBKFhrtBGk1rLgNfRP+XkpngErAi+T7Hw9FfA4XHKhItsX6xmgvaM1pg67FE+BW1QPmJSzO4VKCTMrbwd4HfxpIpL4rk65Waz5IDdH2NwDsyfvjBbgn5P79KcSUpdPXfbkmqaF0t94DyFzhnEoODGaGwDjtXqjc9RMUIlFYBKPJd5ZSDQOFag3v+V0yS7/ERswwOW63vlLOjDFIpM0xhWy8pYf3rTd95nepUx7OU0x974xO4QZV9G1C+jCtlO4inlwqulRKlu1GGusj48Dn5+0+AkQr90X1vBnk3ocpBvDZfx8XQh64EOkUbTAcOVAfQi/IwKN16yRZgBfocMPq4+JP+MYU+NOqsUNZzoB8ASw/H6CJ1jzo4vbGGWoURFx14wEtfGM3wrSsS/E/fmbBjoP1meO2Sn3QIWkeeXqTo+L3VBBZMi0ZQ9ab33CTb7SH3x8qyoEY9eDJkvyBe7aZb506AMlzfnuqfc2EPKARl3lGkCqCTXNEQCqO0+iDdfmHJDEXdp+DKXMKUni8ExMAd9yaqgc95N1ZgGFfdavlhGRSFXi9XUtlWIPX244ksHX5wIPFNtYrixAVg/thIe3KRdVHNY/9xYbJT6lNW9auQ/9xMuQIlFUqOZEO+z5wJODA6S8AJ0b5VycrTm8H0sNdybrWK4tEZ7cv5R2EOjbffVjIePHEySHxNSXbQDGb9kmMJOntALNHgBqBAecAxeT/kkdwXD9Y8d0tbuvHi3NS+JbyfgC5wyxIlEUoz2PdCiKLorMLDcsONCubYBg5uh55+IREUL78ySfsTqdvm0uoQ4hLrDiiQ/zpQMZX3ZPkknlRIyqw4qEBh5oEbXFAbtxzeIuNhQsYzng6IZ25N7SLBBXHFKpGgs49CT0vDidSMjdeCDcIp3zMHJUtDVqBPKDoGQKpq6xwdGOgLdAdfKQoTWrM/9ZbLB/3W1H2WsmOTFLfdlnL8oLEykPZ3E1/o5XGHFcRhDGDoCQVtbfT5qeW+1QwGYp3li5AUjnsIAvfgGNnJ05p27v5BShgr87BSViNBrT0Q96ff1QHB7ZPtBEGyXq/XH/V6wzRFWFyuzhyot/PLFDDOUL8AvQ3UlgbTtCYRAnURUqQ9xPCBcDjsoMK+JjHEcFwkSlpQV5raDXG03lYOslTkaQI3ThXT6jGE2IvsYZ5h/B/1f/zpjUeeWDRhwh8HLrrn5Zc2PDZszVScZ+JBEkXTig1hLuYtpTGBLvO99zkuHb5EkcPPxHz9H96wdfmABT9ddYPXPjDl6LJKIcbTbjSNyC5OSP5NFmoBzaD4KaZIub3hcIYZ5qPGIQO36dolvDnfZjOZbNIhvHMPnXX9y29u8jeLRKniaWYJRJiSCJWqXA8GwM9jqGIxg6KBZqTx3YriNpPeZiowGH+s7MjVW3U2U34b7Zn/mPYXnqGdSimzk72+zaqXUOXowZQWj0eht+9yCEzdiOUJtjpb0poGvSE/PyFP7x1/LBzzFSkUYGyROPWA2ovaAD4JhxV2kSJcQuj5m8sSbFMWcOQaEjpEt/xzvJlFFe4YZ+s1Ber2CDSCeyeKqCK+pCPAPHhPuTRI1yrLLecaErc9DL2cZhT29kHQ5t/ABaIeX/joxbFSRd/F42vtP07SGmkdFtMnXn3LzmDEo0hg46Q4Xc0bIozgakaRgUViAjVklpRNTHv4JScVfLaM8yoSXvbAvP3qMTaAG5EwpcSE9PLH56SV6LxgaUsErkYFTIEuYNHYcPUkNAB7eAXxOoqKrKqH8ienS8rvztsi3kcVCC+CW6qW3DKADbwCgUX4+D23dNUGkny2J6nTCvwKPLzwKmBVZwNfWRdjLSnNZn/0cnMG7i6AjO87zOGeVHw90e+mqKSM9aBiRfC0Rb6kwCGgX2bmRL7BBPav4Gj5EXbQXGV9MVCvQL9+XpyeLOfDcHWfJbrXZAKzgfWoEE6uFlgcDZ4+tldFTdwPgDn/c+pUUbK+NKSFef5ABlunQJv0SCB5zTqKtVQ/AVS9I0EnFa7OY/COZRdij6/eD2ZncLyhh3+z32vpuHjSGRCG7VW78WMu3J13LhECTrIDyvbQ8Sul6zsyiHw9WO/3dmBosi4Ls/BSKzCrfgID+rC5UuLtonJj1sU1zMr4eEOvY5zfR12cL/aHFn8Kl0AWmrfmwGW99sOQv+inWXr+hUEqRJkMRlAv/KTFWPtdRdYsHbCRmgXdWsJcoKBYS3DMKFViTFAEDmm5cBuj0SzfRpUzEoADi5mm8+Qn7sVHq3SiCTLewZxXn0ARTMm4bN83JpXGjftZ6IfLK0hcmKCaK24A5tXc5HbGRFOoZn72b5STykirjkEnri13gMYOqaj/DWBfpd9yLnnInbwpnfLLDFKGE7r+JF8oncwsYl4Zqa4jPl2U7gZJ3Ao5oNtuhYSMq2pO+XHE4S9Zq2psCc7niGYU6fZ7P6WSw5erecTBfQn0enXH9uDz/AeB4H92982uBUaw7UP2/36VzgUjeoOuIN9szi/QpXEPiwHc520ZM6n77+7NgaZV/Qs3KvVI9Trb+XelG3X5CiPpcDxHvLENGHvAdQ/Qui43KJPQBlNb/Y3u4MGysoMH2wZJp7Q3xmyDqj0s0zC8zMo0UqKni37UwCmX16x+duzYZ1fXXD5l4L7EmClZH0YAesoN67lmBXwNklsx54ma/mxcOnbI89LPOHt4Sf1QyfNVoGgy2+ZPbcDJMU4fPjXCCF7CgTqdbrfTiToIr8BEJu7YIp1BBX0JUgedfzxFx0UERRNNz1gIySIlUJQWW/C7IOV+fejqdJ0VDF3i45osjg7C+JSD8HPIjiowcmRf4QtX6/qFXBORLENWSBBRbuqiLFUwZINv8e/EICUbYSawU8E/9aa7HWVgA2V7GF+qrAlChONfnQCmvsC3ahfjoZSkpGJ7TvT+Oc4Ho3aF7Ioy+qSF2TMYFPRuvgVg8IOtSmvYEFfzcRPo1ZeIQ5Pxw2blB3xIV+u0nnyxoxLzdzdjT6OU0oNEtnZL+CZDNrYBLGfD6dwc53MHq0cBXW8lbAUz1pz6WTiNUwKF4RJ+WB4w9lLCOWA5xhGudM6soZ7mMft6LWHo/dbeFo92mHjrON/rDEZq9vZiIQ39n/LdpYzDoew2EpRqHjPOqmqlmeq7GJqKFSuYqJKTxZjzlLjzQHYSgmpaHnqQP+UDxpHq9Clrx5sn3pO4V7C3+/6QwdCHmSiaomoyKPx9QFe6f/cgSIeU15cwhFw7Rqy5bnpbJ8K+AKnN6baaePJzP0QwcHRQp0sVeyRluFK3VnMdV09SdFw6IGjMAX0J0JaY+Zbopy6qCiapoPdPCxLp1z4G6VjjROEnl1OQHh9/+yeg95rPssLLCr5+K+InifZ+YghOkMHoxmIpqtknIRV5PVEtnPqeSnQBJDCvKLw3HgAT6LOwAXDg8v5ejhOEiMBxZ8e+PVNhN5LebGsO2Przxufmzr298Y4JM3q9JalgkqUJtc0sK5spBSht+aDPQ29qz/Ia8mzg3wNGnQlClwM0aNCgQYMGDRo0aNCgQYMGDRo0aNCgQYMGDRo0aNCgQYMGDRo0aOgA/w9Ak2/tAPAtWQAAAABJRU5ErkJggg\u003d\u003d"
   },
-  "description": "Sends events to the Klaviyo",
+  "description": "Tag for sending events, managing profile information, and adding profiles to lists on the Klaviyo platform.",
   "containerContexts": [
     "SERVER"
   ]
@@ -97,14 +97,14 @@ ___TEMPLATE_PARAMETERS___
     "displayName": "Email",
     "simpleValueType": true,
     "alwaysInSummary": false,
-    "help": "Email of the user"
+    "help": "Email of the user."
   },
   {
     "type": "TEXT",
     "name": "phone",
     "displayName": "Phone",
     "simpleValueType": true,
-    "help": "Phone number of the user needed for SMS marketing",
+    "help": "Phone number of the user needed for SMS marketing.\n\u003cbr\u003e\nThe phone number must be in E.164 standard: +\u003cContry Code\u003e\u003cPhone number with area code\u003e.\n\u003cbr\u003e\nExample: \n\u003cul\u003e\n\u003cli\u003eUS phone number: (650) 555-1212\u003c/li\u003e\n\u003cli\u003eE.164 standard for this number: +16505551212\u003c/li\u003e\n\u003c/ul\u003e",
     "enablingConditions": [
       {
         "paramName": "subscribeToMarketingSMS",
@@ -173,7 +173,7 @@ ___TEMPLATE_PARAMETERS___
         "type": "EQUALS"
       }
     ],
-    "help": "Pass marketing consent state as SUBSCRIBED"
+    "help": "Pass marketing consent state as SUBSCRIBED.\n\u003cbr\u003e\nAt least one of the following must be selected: \u003cb\u003emarketing emails\u003c/b\u003e or \u003cb\u003emarketing SMS\u003c/b\u003e."
   },
   {
     "type": "CHECKBOX",
@@ -187,14 +187,14 @@ ___TEMPLATE_PARAMETERS___
         "type": "EQUALS"
       }
     ],
-    "help": "Pass marketing consent state as SUBSCRIBED"
+    "help": "Pass marketing consent state as SUBSCRIBED.\n\u003cbr\u003e\nAt least one of the following must be selected: \u003cb\u003emarketing emails\u003c/b\u003e or \u003cb\u003emarketing SMS\u003c/b\u003e."
   },
   {
     "type": "CHECKBOX",
     "name": "useOptimisticScenario",
     "checkboxText": "Use Optimistic Scenario",
     "simpleValueType": true,
-    "help": "The tag will call gtmOnSuccess() without waiting for a response from the API"
+    "help": "The tag will call gtmOnSuccess() without waiting for a response from the API. This will speed up sGTM response time however your tag will always return the status fired successfully even in case it is not."
   },
   {
     "type": "CHECKBOX",
@@ -614,7 +614,7 @@ const actionTypes = {
   ACTIVE_ON_SITE: 'active_on_site',
   CREATE_OR_UPDATE_PROFILE: 'createOrUpdateProfile'
 };
-const klaviyoApiRevision = '2024-06-15';
+const klaviyoApiRevision = '2025-01-15';
 
 const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = isLoggingEnabled ? getRequestHeader('trace-id') : undefined;
@@ -647,37 +647,31 @@ function sendEvent() {
   if (!hasUserIdentificationData(klaviyoEventData)) {
     return data.gtmOnSuccess();
   }
-  
+
   const url = 'https://a.klaviyo.com/api/events/';
 
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Klaviyo',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: eventNameLogs,
-        RequestMethod: 'POST',
-        RequestUrl: url,
-        RequestBody: klaviyoEventData
-      })
-    );
-  }
+  log({
+    Name: 'Klaviyo',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: eventNameLogs,
+    RequestMethod: 'POST',
+    RequestUrl: url,
+    RequestBody: klaviyoEventData
+  });
 
   sendHttpRequest(
     url,
     (statusCode, headers, body) => {
-      logToConsole(
-        JSON.stringify({
-          Name: 'Klaviyo',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: eventNameLogs,
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body
-        })
-      );
+      log({
+        Name: 'Klaviyo',
+        Type: 'Response',
+        TraceId: traceId,
+        EventName: eventNameLogs,
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
 
       if (!data.useOptimisticScenario) {
         if (statusCode >= 200 && statusCode < 300) {
@@ -723,7 +717,7 @@ function addToList() {
       }
     }
   };
-  
+
   const subscriptions = {};
   if (data.subscribeToMarketingEmails) {
     subscriptions.email = {
@@ -738,42 +732,32 @@ function addToList() {
         consent: 'SUBSCRIBED'
       }
     };
-    let phone = '';
-    if (data.phone) {
-      phone = data.phone;
-    }
-    addToListData.data.attributes.profiles.data[0].attributes.phone_number = phone;
+    addToListData.data.attributes.profiles.data[0].attributes.phone_number = data.phone || '';
   }
   addToListData.data.attributes.profiles.data[0].attributes.subscriptions = subscriptions;
 
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Klaviyo',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: 'add_to_list',
-        RequestMethod: 'POST',
-        RequestUrl: url,
-        RequestBody: addToListData
-      })
-    );
-  }
+  log({
+    Name: 'Klaviyo',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: 'add_to_list',
+    RequestMethod: 'POST',
+    RequestUrl: url,
+    RequestBody: addToListData
+  });
 
   sendHttpRequest(
     url,
     (statusCode, headers, body) => {
-      logToConsole(
-        JSON.stringify({
-          Name: 'Klaviyo',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: 'add_to_list',
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body
-        })
-      );
+      log({
+        Name: 'Klaviyo',
+        Type: 'Response',
+        TraceId: traceId,
+        EventName: 'add_to_list',
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
 
       if (!data.useOptimisticScenario) {
         if (statusCode >= 200 && statusCode < 300) {
@@ -793,39 +777,33 @@ function addToList() {
 
 function createOrUpdateProfile() {
   const url = 'https://a.klaviyo.com/api/profile-import/';
-  
+
   const updateProfileData = {
     data: getProfileData()
   };
-  
-  if (isLoggingEnabled) {
-    logToConsole(
-      JSON.stringify({
-        Name: 'Klaviyo',
-        Type: 'Request',
-        TraceId: traceId,
-        EventName: 'createOrUpdateProfile',
-        RequestMethod: 'POST',
-        RequestUrl: url,
-        RequestBody: updateProfileData
-      })
-    );
-  }
-  
+
+  log({
+    Name: 'Klaviyo',
+    Type: 'Request',
+    TraceId: traceId,
+    EventName: 'createOrUpdateProfile',
+    RequestMethod: 'POST',
+    RequestUrl: url,
+    RequestBody: updateProfileData
+  });
+
   sendHttpRequest(
     url,
     (statusCode, headers, body) => {
-      logToConsole(
-        JSON.stringify({
-          Name: 'Klaviyo',
-          Type: 'Response',
-          TraceId: traceId,
-          EventName: 'createOrUpdateProfile',
-          ResponseStatusCode: statusCode,
-          ResponseHeaders: headers,
-          ResponseBody: body
-        })
-      );
+      log({
+        Name: 'Klaviyo',
+        Type: 'Response',
+        TraceId: traceId,
+        EventName: 'createOrUpdateProfile',
+        ResponseStatusCode: statusCode,
+        ResponseHeaders: headers,
+        ResponseBody: body
+      });
 
       if (!data.useOptimisticScenario) {
         if (statusCode >= 200 && statusCode < 300) {
@@ -1023,10 +1001,7 @@ function getViewedItems() {
 
 function updateViewedItems(viewedItems) {
   for (let key in viewedItems) {
-    if (
-      viewedItems[key].ItemId &&
-      makeString(viewedItems[key].ItemId) === eventData.ItemId
-    ) {
+    if (viewedItems[key].ItemId && makeString(viewedItems[key].ItemId) === eventData.ItemId) {
       viewedItems[key].Views = makeInteger(viewedItems[key].Views) + 1;
 
       return viewedItems;
@@ -1065,20 +1040,25 @@ function hasItem(arr, item) {
   for (let k in arr) {
     if (arr[k] === item) return true;
   }
-
   return false;
 }
 
 function buildRequestHeaders() {
   return {
-    'X-Forwarded-For': eventData.ip_override 
+    'X-Forwarded-For': eventData.ip_override
       ? eventData.ip_override.split(' ').join('').split(',')[0]
       : getRemoteAddress(),
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
+    'Content-Type': 'application/vnd.api+json',
+    Accept: 'application/vnd.api+json',
     Revision: klaviyoApiRevision,
     Authorization: 'Klaviyo-API-Key ' + data.apiKey
   };
+}
+
+function log(logObject) {
+  if (isLoggingEnabled) {
+    logToConsole(JSON.stringify(logObject));
+  }
 }
 
 function determinateIsLoggingEnabled() {


### PR DESCRIPTION
Hi.

I've reviewed all the endpoints used by the tag, and only the Add to List method is affected by the API version update.

Old API version: [Reference](https://developers.klaviyo.com/en/v2024-06-15/reference/subscribe_profiles)
New API version: [Reference](https://developers.klaviyo.com/en/v2025-01-15/reference/subscribe_profiles)

**Before the API Version Update**

Add to List Method
- The previous API version did not require a subscription object with consent information.
- However, the subscription object was always included in the request, regardless of whether the consent checkboxes were marked.
- As a result, when the checkboxes were not marked, the request would fail due to an empty subscription object.
- Therefore, the tag only functioned correctly when at least one checkbox was selected.

**After the API Version Update**

Add to List Method
- The new API version requires a subscription object with consent information.
- To align with this change, I’ve updated the checkboxes "Subscribe to marketing emails" and "Subscribe to marketing SMS" to clarify that at least one must be selected.